### PR TITLE
GitHub maven runner fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "dev", "backend", "frontend" ]
+    branches: [ "dev", "backend" ]
   pull_request:
-    branches: [ "dev", "backend", "frontend" ]
+    branches: [ "dev", "backend" ]
 
 jobs:
   build:


### PR DESCRIPTION
Fix the Maven runner so that it would only be executed on "dev" and "backend" branches, as well as use pom.xml file from the correct location.