### PR TITLE
bugfix/issue-125/fix-openjdk-distribution-error

### DIFF
--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 21  
-          distribution: temurin
+          java-version: '21'  
+          distribution: 'temurin'
 
       # Step 3: Build the JAR file with Maven
       - name: Build JAR


### PR DESCRIPTION
Changed the distribution to temurin to fix the error: "No supported distribution was found for input openjdk".

### Issue(s):
#125 

### Type of change: (choose required ones)
- Bug fix
- 
### Description:
Fix for "Error: No supported distribution was found for input openjdk". Changed "OpenJDK" to "temurin" in the distribution.

### Testing instructions:
Tests for the GitHub action should start passing.
