### PR TITLE
bugfix/issue-163/keystore-integration-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To get started with developing or contributing to this project, follow the steps
 6. **Open the Project in Your IDE**:
    Open the cloned repository in your preferred Integrated Development Environment (IDE) (we recommend IntelliJ) for further development.
 
-7. **Add keystore.p12 file to the root of the cloned repository**:
+7. **Add keystore.p12 file to backend/src/main/resources in the cloned repository**:
     Keystore has to contain both private key and full certificate chain files.
     Not adding the keystore file will result in unencrypted (non-HTTPS) connection.
 


### PR DESCRIPTION

### Issue(s):
#163 

### Type of change: (choose required ones)
- Documentation update

### Description:
Changed developer instructions, where instead of moving keystore.p12 to the root of the repository, it should instead be moved to backend/src/main/resources. In order to prevent the backend from launching without https when key is present.