### PR TITLE
bugfix/issue 230/typing-like-bug

### DIFF
--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -49,9 +49,10 @@
               <strong v-else>{{ msg.sender }}</strong>
               <!-- For assistant messages, use TypingText to animate the output -->
               <TypingText 
-                v-if="msg.sender === 'assistant'" 
+                v-if="msg.sender === 'assistant' && !animatedMessages[index]" 
                 :text="formatMessage(msg.content)" 
                 :speed="15" 
+                @finished="animatedMessages[index] = true"
               />
               <!-- For non-assistant messages, render markdown as HTML -->
               <p v-else v-html="formatMessage(msg.content)"></p>

--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -106,7 +106,6 @@ export default {
       currentTurn: "user", // Tracks conversation turn (user or AI)
       userId: localStorage.getItem("userId") || "",
       currentTheme: "default", // Stores the current UI theme
-      finishedMessages: {}  
     };
   },
   props: ["messages", "chats", "currentChatID", "currentLanguage", "chatInitButtonsDisabled"],

--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -101,6 +101,7 @@ export default {
       currentTurn: "user", // Tracks conversation turn (user or AI)
       userId: localStorage.getItem("userId") || "",
       currentTheme: "default", // Stores the current UI theme
+      animatedMessages: {} // Track whether each assistant message's typing effect is finished
     };
   },
   props: ["messages", "chats", "currentChatID", "currentLanguage", "chatInitButtonsDisabled"],

--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -48,12 +48,15 @@
               <strong v-else-if="msg.sender === 'assistant'">{{ getTranslation(currentLanguage, "AI") }}</strong>
               <strong v-else>{{ msg.sender }}</strong>
               <!-- For assistant messages, use TypingText to animate the output -->
+              <div v-if="msg.sender === 'assistant'">
               <TypingText 
-                v-if="msg.sender === 'assistant' && !animatedMessages[msg.id]" 
+                v-if="!finishedMessages[`${currentChatID}-${index}`]" 
                 :text="formatMessage(msg.content)" 
                 :speed="15" 
-                @finished="animatedMessages[msg.id] = true"
+                @finished="finishedMessages[`${currentChatID}-${index}`] = formatMessage(msg.content)"
               />
+              <p v-else v-html="finishedMessages[`${currentChatID}-${index}`]"></p>
+              </div>
               <!-- For non-assistant messages, render markdown as HTML -->
               <p v-else v-html="formatMessage(msg.content)"></p>
             </div>
@@ -102,7 +105,7 @@ export default {
       currentTurn: "user", // Tracks conversation turn (user or AI)
       userId: localStorage.getItem("userId") || "",
       currentTheme: "default", // Stores the current UI theme
-      animatedMessages: {} // Track whether each assistant message's typing effect is finished
+      finishedMessages: {}  
     };
   },
   props: ["messages", "chats", "currentChatID", "currentLanguage", "chatInitButtonsDisabled"],

--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -49,10 +49,10 @@
               <strong v-else>{{ msg.sender }}</strong>
               <!-- For assistant messages, use TypingText to animate the output -->
               <TypingText 
-                v-if="msg.sender === 'assistant' && !animatedMessages[index]" 
+                v-if="msg.sender === 'assistant' && !animatedMessages[msg.id]" 
                 :text="formatMessage(msg.content)" 
                 :speed="15" 
-                @finished="animatedMessages[index] = true"
+                @finished="animatedMessages[msg.id] = true"
               />
               <!-- For non-assistant messages, render markdown as HTML -->
               <p v-else v-html="formatMessage(msg.content)"></p>

--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -50,12 +50,13 @@
               <!-- For assistant messages, use TypingText to animate the output -->
               <div v-if="msg.sender === 'assistant'">
               <TypingText 
-                v-if="!finishedMessages[`${currentChatID}-${index}`]" 
+                v-if="!getFinishedMessage(index)" 
                 :text="formatMessage(msg.content)" 
                 :speed="15" 
-                @finished="finishedMessages[`${currentChatID}-${index}`] = formatMessage(msg.content)"
+                @finished="setFinishedMessage(index, formatMessage(msg.content))"
               />
-              <p v-else v-html="finishedMessages[`${currentChatID}-${index}`]"></p>
+              <!-- Otherwise, render the static text from localStorage -->
+              <p v-else v-html="getFinishedMessage(index)"></p>
               </div>
               <!-- For non-assistant messages, render markdown as HTML -->
               <p v-else v-html="formatMessage(msg.content)"></p>
@@ -202,6 +203,17 @@ export default {
         this.requestChatHistory();
       });
     },
+
+    // Returns the finished message text for a given index if it exists in localStorage.
+  getFinishedMessage(index) {
+    const key = `finishedMessage_${this.currentChatID}_${index}`;
+    return localStorage.getItem(key);
+  },
+  // Saves the finished message text for a given index into localStorage.
+  setFinishedMessage(index, text) {
+    const key = `finishedMessage_${this.currentChatID}_${index}`;
+    localStorage.setItem(key, text);
+  },
 
     /**
      * Requests chat history from the server based on the current chat ID.

--- a/frontend/src/components/helpers/TypingText.vue
+++ b/frontend/src/components/helpers/TypingText.vue
@@ -44,6 +44,7 @@
             index++;
           } else {
             clearInterval(this.timer);
+            this.$emit('finished');
           }
         }, this.speed);
       }

--- a/frontend/src/components/helpers/TypingText.vue
+++ b/frontend/src/components/helpers/TypingText.vue
@@ -44,7 +44,6 @@
             index++;
           } else {
             clearInterval(this.timer);
-            this.$emit('finished');
           }
         }, this.speed);
       }

--- a/frontend/src/components/helpers/TypingText.vue
+++ b/frontend/src/components/helpers/TypingText.vue
@@ -44,6 +44,8 @@
             index++;
           } else {
             clearInterval(this.timer);
+            // Emit an event when finished typing
+            this.$emit('finished');
           }
         }, this.speed);
       }


### PR DESCRIPTION
### Issue(s):
#230 

### Type of change: 
- Bug fix

### Description:
The "typing-like" AI responses only happen once now, when the message is first outputted. You can switch between chats and messages that already exist and it won't go through the "typing-like" response again. 

### Additional context:
CI/CD is failing because the university has run out of credits for GitHub Actions.

### Testing instructions:
Run the solution on this branch, create 2 or more chats, and interact with the AI for a bit. Verify that:

1. The "typing-like" effect happens when the AI first responds.
2. The messages stay static after switching between chats.
3. Try refreshing the page and checking if it still works.
