### PR TITLE
Bugfix/issue 232/implement openai secret

### DIFF
--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -81,5 +81,5 @@ jobs:
             docker pull ghcr.io/spe-uob/2024-ailearningtool:latest
             docker stop ailearningtool || true
             docker rm ailearningtool || true
-            docker run -d --name ailearningtool -p 443:443 ghcr.io/spe-uob/2024-ailearningtool:latest -v keystore.p12:/keystore.p12
+            sudo docker run -d --name ailearningtool -p 443:443 ghcr.io/spe-uob/2024-ailearningtool:latest -v /keystore.p12:/keystore.p12
 

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BACKEND_URL: ailearningtool.ddns.net
-      OPENAI_API_KEY: secrets.OPENAI_API_KEY
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       # Step 1: Checkout the repository
       - name: Checkout repository
@@ -28,7 +28,7 @@ jobs:
 
       # Step 3: Adjust OpenAI API key.
       - name: Adjust the OpenAI API key
-        run: (envsubst < OpenAIAuthenticator.java) > OpenAIAuthenticator.java
+        run: (envsubst < OpenAIAuthenticator.java) > OpenAIAuthenticatorUPD.java && cp OpenAIAuthenticatorUPD.java OpenAIAuthenticator.java && rm OpenAIAuthenticatorUPD.java
         working-directory: backend/src/main/java/com/UoB/AILearningTool
 
       # Step 4: Adjust the backend application parameters

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -35,13 +35,13 @@ jobs:
           server.servlet.encoding.charset=UTF-8\n\
           server.servlet.encoding.enabled=true\n\
           server.servlet.encoding.force=true\n\
-          server.ssl.key-store=classpath:keystore.p12\n\
+          server.ssl.key-store=./file:keystore.p12\n\
           server.ssl.key-store-password=ailearntool" > application.properties
         working-directory: backend/src/main/resources
 
       # Step 4: Adjust the frontend BACKEND_URL constant
       - name: Update frontend BACKEND_URL constant
-        run : echo "const BACKEND_URL = 'http://" + $BACKEND_URL + "';
+        run : echo "const BACKEND_URL = 'http://$BACKEND_URL';
               export { BACKEND_URL };" > globalConstants.js
         working-directory: frontend/src/assets
         

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - dev
       - feature/issue-203/fix-CD-runner
+      - bugfix/issue-232/implement-openai-secret
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BACKEND_URL: ailearningtool.ddns.net
+      OPENAI_API_KEY: secrets.OPENAI_API_KEY
     steps:
       # Step 1: Checkout the repository
       - name: Checkout repository
@@ -24,7 +25,12 @@ jobs:
           java-version: '21'  
           distribution: 'temurin'
 
-      # Step 3: Adjust the backend application parameters
+      # Step 3: Adjust OpenAI API key.
+      - name: Adjust the OpenAI API key
+        run: (envsubst < OpenAIAuthenticator.java) > OpenAIAuthenticator.java
+        working-directory: backend/src/main/java/com/UoB/AILearningTool
+
+      # Step 4: Adjust the backend application parameters
       - name: Adjust the backend URL
         run: | 
           echo -e "spring.application.name=AILearningTool\n\
@@ -39,22 +45,22 @@ jobs:
           server.ssl.key-store-password=ailearntool" > application.properties
         working-directory: backend/src/main/resources
 
-      # Step 4: Adjust the frontend BACKEND_URL constant
+      # Step 5: Adjust the frontend BACKEND_URL constant
       - name: Update frontend BACKEND_URL constant
         run : echo "const BACKEND_URL = 'http://$BACKEND_URL';
               export { BACKEND_URL };" > globalConstants.js
         working-directory: frontend/src/assets
         
-      # Step 5: Build the JAR file with Maven
+      # Step 6: Build the JAR file with Maven
       - name: Build JAR
         run: mvn clean package
         working-directory: backend
 
-      # Step 6: Log in to GitHub Container Registry
+      # Step 7: Log in to GitHub Container Registry
       - name: Log in to GHCR
         run: echo "${{ secrets.CONTAINER_REGISTRY_PAT }}" | docker login ghcr.io -u GerardChabaBristol --password-stdin
 
-      # Step 7: Build and push the Docker image
+      # Step 8: Build and push the Docker image
       - name: Publish Docker image to GHCR
         uses: docker/build-push-action@v3
         with:
@@ -63,7 +69,7 @@ jobs:
           push: true
           tags: ghcr.io/spe-uob/2024-ailearningtool:latest
 
-      # Step 8: Pull the image and deploy on the server
+      # Step 9: Pull the image and deploy on the server
       - name: Deploy to Server
         uses: appleboy/ssh-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 backend/target
 backend/.idea
 backend/src/main/resources/keystore.p12
+backend/src/main/java/com/UoB/AILearningTool/OpenAIAuthenticator.java
+backend/database.db
 backend/src/main/resources/static/*
 
 frontend/dist

--- a/backend/src/main/java/com/UoB/AILearningTool/AiLearningToolApplication.java
+++ b/backend/src/main/java/com/UoB/AILearningTool/AiLearningToolApplication.java
@@ -18,6 +18,7 @@ public class AiLearningToolApplication {
 		//  disable SSL if launched without keystore.p12
 		if (!Files.exists(Paths.get("keystore.p12"))) {
 			// Force disable SSL
+			System.out.println("keystore.p12 not found");
 			System.setProperty("server.ssl.enabled", "false");
 		}
 		SpringApplication.run(AiLearningToolApplication.class, args);

--- a/backend/src/main/java/com/UoB/AILearningTool/OpenAIAuthenticator.java
+++ b/backend/src/main/java/com/UoB/AILearningTool/OpenAIAuthenticator.java
@@ -1,5 +1,4 @@
 package com.UoB.AILearningTool;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -10,21 +9,21 @@ import org.slf4j.LoggerFactory;
 
 public class OpenAIAuthenticator {
     private final Logger log = LoggerFactory.getLogger(OpenAIAuthenticator.class);
-    
+
     private String apiKey;
 
     // Constructor that initializes the API key
     public OpenAIAuthenticator() {
-        this.apiKey = "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"; 
-        log.info("OpenAI API key set.");
+          this.apiKey = "SOMEKEY";
+          log.info("OpenAI API key set.");
     }
 
     // Returns the API key as a "Bearer token" (used in authorization headers)
     public String getBearerToken() {
-        if (this.apiKey == null || this.apiKey.isEmpty()) {
-            log.error("API Key not set or is empty.");
-            throw new IllegalStateException("API Key for OpenAI is not set.");
-        }
-        return this.apiKey;
+      if (this.apiKey == null || this.apiKey.equals("SOMEKEY") || this.apiKey.isEmpty()) {
+        log.error("API Key not set or is empty.");
+        throw new IllegalStateException("API Key for OpenAI is not set.");
+      }
+      return this.apiKey;
     }
 }

--- a/backend/src/main/java/com/UoB/AILearningTool/OpenAIAuthenticator.java
+++ b/backend/src/main/java/com/UoB/AILearningTool/OpenAIAuthenticator.java
@@ -14,13 +14,13 @@ public class OpenAIAuthenticator {
 
     // Constructor that initializes the API key
     public OpenAIAuthenticator() {
-          this.apiKey = "SOMEKEY";
+          this.apiKey = "$OPENAI_API_KEY";
           log.info("OpenAI API key set.");
     }
 
     // Returns the API key as a "Bearer token" (used in authorization headers)
     public String getBearerToken() {
-      if (this.apiKey == null || this.apiKey.equals("SOMEKEY") || this.apiKey.isEmpty()) {
+      if (this.apiKey == null || this.apiKey.equals("OPENAI_API_KEY") || this.apiKey.isEmpty()) {
         log.error("API Key not set or is empty.");
         throw new IllegalStateException("API Key for OpenAI is not set.");
       }

--- a/localExecute.sh
+++ b/localExecute.sh
@@ -1,16 +1,56 @@
 #!/bin/bash
 # Initialising the server outside of Docker container, eg. for development
 # and debugging purposes. No SSL is used.
+# First argument - openAI API key
+# Second argument - preferred port number (optional)
 # Preferred port number can be provided as an integer number
-# in range 0-65535, for example
-#       ./localExecute.sh 9000
-#       ./localExecute.sh 65535
-# If no argument is provided or the range is incorrect, a standard port 8080 is used.
+# in range 0-65535.
+# Usage examples:
+#       ./localExecute.sh somerandomOpenAIAPIKey1 9000
+#       ./localExecute.sh somestrangeunreadableopenaiapikey 9000
+# If no port argument is provided or the range is incorrect, a standard port 8080 is used.
 
-# Processes the argument (if provided)
-if [ "$1" != "" ] && [ "$1" -ge 0 ] && [ "$1" -le 65535 ]
+# Process the OpenAI API key argument (if provided)
+if [ "$1" != "" ]
 then
-PORT=$1
+echo "package com.UoB.AILearningTool;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenAIAuthenticator {
+    private final Logger log = LoggerFactory.getLogger(OpenAIAuthenticator.class);
+
+    private String apiKey;
+
+    // Constructor that initializes the API key
+    public OpenAIAuthenticator() {
+          this.apiKey = \"$1\";
+          log.info(\"OpenAI API key set.\");
+    }
+
+    // Returns the API key as a \"Bearer token\" (used in authorization headers)
+    public String getBearerToken() {
+      if (this.apiKey == null || this.apiKey.equals(\"SOMEKEY\") || this.apiKey.isEmpty()) {
+        log.error(\"API Key not set or is empty.\");
+        throw new IllegalStateException(\"API Key for OpenAI is not set.\");
+      }
+      return this.apiKey;
+    }
+}" > backend/src/main/java/com/UoB/AILearningTool/OpenAIAuthenticator.java
+else
+echo "OpenAI API key not provided!"
+exit 1
+fi
+
+# Processes the port argument (if provided)
+if [ "$2" != "" ] && [ "$2" -ge 0 ] && [ "$2" -le 65535 ]
+then
+PORT=$2
 else
 PORT=8080
 fi

--- a/localExecute.sh
+++ b/localExecute.sh
@@ -35,7 +35,7 @@ public class OpenAIAuthenticator {
 
     // Returns the API key as a \"Bearer token\" (used in authorization headers)
     public String getBearerToken() {
-      if (this.apiKey == null || this.apiKey.equals(\"SOMEKEY\") || this.apiKey.isEmpty()) {
+      if (this.apiKey == null || this.apiKey.equals(\"OPENAI_API_KEY\") || this.apiKey.isEmpty()) {
         log.error(\"API Key not set or is empty.\");
         throw new IllegalStateException(\"API Key for OpenAI is not set.\");
       }


### PR DESCRIPTION
### Issue(s):
#232 

### Type of change: (choose required ones)
- Bug fix

### Description:
The CD runner now adds OpenAI API key, instead of keeping it hardcoded as before.
`./localExecute.sh` now allows to customise the OpenAI key used.

### Additional context:
See the result of runner execution.

### Testing instructions:
See the result of runner execution.
