### PR TITLE
bugfix/issue-229/invisible-course-links

### DIFF
--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -550,4 +550,11 @@ button {
 .tts-button:hover {
 color: var(--accent-color);
 }
+
+/* Ensure links in messages are visible */
+.messages-container a {
+  color: blue;
+  text-decoration: underline;
+}
+
 </style>


### PR DESCRIPTION
### Issue(s):
#229 

### Type of change: (choose required ones)
- Bug fix


### Description:
Changed the colour of links provided by the chatbot to blue and to be underlined, in order to fix the issue of links appearing invisible.

![image](https://github.com/user-attachments/assets/9d44fba8-5ad1-482f-b1c0-54ab60d432af)


### Testing instructions:
Prompt the chatbot to provide you course links, and check if the links are now visible.